### PR TITLE
Add LG UltraFine 4K to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Download the latest app binary zip file from [here](https://github.com/czarny/Br
 * DELL U2717D
 * DELL U3818DW
 * LG IPS235
+* LG UltraFine 4K 
+  - _Need to restart application when plugging in and out monitors_
 * IIYAMA PL2779Q
 * ASUS AS239
 * Fujitsu P27T-7


### PR DESCRIPTION
I've been using Brisync for about half a year with these monitors, works great if I start Brisync after plugging in monitors. Need to restart application if I've used the computer without them.